### PR TITLE
Add start-hidden-in-tray preference & UI

### DIFF
--- a/AppData/Preferences.py
+++ b/AppData/Preferences.py
@@ -49,6 +49,7 @@ class General(Serializable):
         self._openProgressWindow = True
         self._notify = True
         self._useSystemTray = False
+        self._startHiddenInTray = False
         self._bookmarks = []
 
     def setOpenProgressWindowEnabled(self, enabled: bool) -> None:
@@ -59,6 +60,9 @@ class General(Serializable):
 
     def setSystemTrayEnabled(self, enabled: bool) -> None:
         self._useSystemTray = enabled
+
+    def setStartHiddenInTrayEnabled(self, enabled: bool) -> None:
+        self._startHiddenInTray = enabled
 
     def setBookmarks(self, bookmarks: list[str]) -> None:
         self._bookmarks = bookmarks
@@ -71,6 +75,9 @@ class General(Serializable):
 
     def isSystemTrayEnabled(self) -> bool:
         return self._useSystemTray
+
+    def isStartHiddenInTrayEnabled(self) -> bool:
+        return self._startHiddenInTray
 
     def getBookmarks(self) -> list[str]:
         return self._bookmarks

--- a/Ui/AccountImportProgressView.py
+++ b/Ui/AccountImportProgressView.py
@@ -50,7 +50,7 @@ class AccountImportProgressView(QtWidgets.QDialog):
     def _browserProfileUpdated(self, browserProfile: BrowserProfile) -> None:
         if not self._cancelRequested:
             importInfoText = T("#Importing Twitch account from {browserName}", ellipsis=True, browserName=browserProfile.browserName)
-            profileInfoText = f"{T("profile")}: {browserProfile.displayName}({browserProfile.key})"
+            profileInfoText = f"{T('profile')}: {browserProfile.displayName}({browserProfile.key})"
             if len(self._profiles) > 1:
                 self._ui.progressInfo.setText(f"{importInfoText}\n{profileInfoText}")
             else:

--- a/Ui/MainWindow.py
+++ b/Ui/MainWindow.py
@@ -16,6 +16,7 @@ class MainWindow(QtWidgets.QMainWindow, WindowGeometryManager):
         super().__init__(parent=parent)
         self._ui = UiLoader.load("mainWindow", self)
         self._webViewEnabled = False
+        # startup flags
         App.Instance.appStarted.connect(self.start, QtCore.Qt.ConnectionType.QueuedConnection)
 
     def start(self) -> None:
@@ -28,13 +29,25 @@ class MainWindow(QtWidgets.QMainWindow, WindowGeometryManager):
             loading = Ui.Loading()
             loading.completeSignal.connect(self.onLoadingComplete)
             loading.exec()
-            self.show()
+            # If user requested start-hidden, show the window off-screen briefly to register it
+            if App.Preferences.general.isStartHiddenInTrayEnabled() and Utils.isMinimizeToSystemTraySupported():
+                try:
+                    self.move(-10000, -10000)
+                except:
+                    pass
+                self.show()
+                QtCore.QTimer.singleShot(0, self.moveToSystemTray)
+            else:
+                self.show()
 
     def onLoadingComplete(self) -> None:
         self.loadWindowGeometry()
         self.loadComponents()
         self.setupSystemTray()
         self.setup()
+        if App.Preferences.general.isStartHiddenInTrayEnabled():
+            self.moveToSystemTray()
+        
 
     def loadComponents(self) -> None:
         self.setWindowIcon(Icons.APP_LOGO.icon)
@@ -316,6 +329,11 @@ class MainWindow(QtWidgets.QMainWindow, WindowGeometryManager):
 
     def activate(self) -> None:
         if self.isHidden():
+            try:
+                # restore last saved geometry so window appears on-screen
+                self.loadWindowGeometry()
+            except:
+                pass
             self.show()
         self.setWindowState((self.windowState() & ~QtCore.Qt.WindowState.WindowMinimized) | QtCore.Qt.WindowState.WindowActive)
         self.raise_()

--- a/Ui/Settings.py
+++ b/Ui/Settings.py
@@ -15,8 +15,11 @@ class Settings(QtWidgets.QWidget):
         self._ui.notify.toggled.connect(App.Preferences.general.setNotifyEnabled)
         self._ui.windowClose.setCurrentIndex(1 if App.Preferences.general.isSystemTrayEnabled() else 0)
         self._ui.windowClose.currentIndexChanged.connect(self.windowCloseChanged)
+        self._ui.startHiddenInTray.setChecked(App.Preferences.general.isStartHiddenInTrayEnabled())
+        self._ui.startHiddenInTray.toggled.connect(App.Preferences.general.setStartHiddenInTrayEnabled)
         if not Utils.isMinimizeToSystemTraySupported():
             self._ui.windowCloseArea.hide()
+            self._ui.startHiddenInTrayArea.hide()
         self.streamTemplateInfoWindow = FileNameTemplateInfo(FileNameTemplateInfo.TYPE.STREAM, parent=self)
         self._ui.streamFilename.setText(App.Preferences.templates.getStreamFilename())
         self._ui.streamFilename.editingFinished.connect(self.setStreamFilename)

--- a/resources/ui/settings.ui
+++ b/resources/ui/settings.ui
@@ -123,6 +123,31 @@
             </layout>
            </widget>
           </item>
+          <item>
+           <widget class="QWidget" name="startHiddenInTrayArea" native="true">
+            <layout class="QHBoxLayout" name="startHiddenInTrayAreaLayout">
+             <property name="leftMargin">
+              <number>0</number>
+             </property>
+             <property name="topMargin">
+              <number>0</number>
+             </property>
+             <property name="rightMargin">
+              <number>0</number>
+             </property>
+             <property name="bottomMargin">
+              <number>0</number>
+             </property>
+             <item>
+              <widget class="QCheckBox" name="startHiddenInTray">
+               <property name="text">
+                <string>Start application hidden in system tray</string>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </widget>
+          </item>
          </layout>
         </widget>
        </item>


### PR DESCRIPTION
Hello! I recently opened an issue and tried to implement it myself, im a noob at everything so im not sure if it can be used as-is for a release, might want to check that. I can say it works on my machine and im satisfied with the result so i wanted to share it in case it could help you.

Changes:
Introduce a new 'startHiddenInTray' preference to General (getter and setter) and wire it into the Settings UI so users can opt to start the app hidden in the system tray. 
-Update resources/ui/settings.ui to add a checkbox area, and hide that area when minimize-to-tray is not supported. 
-Modify MainWindow to honor the flag on startup by briefly showing the window off-screen (to register it) then moving it to the system tray after initialization, and restore saved geometry when activating the window. 
-Also include a small quoting fix in AccountImportProgressView to avoid nested double-quote syntax errors.